### PR TITLE
Update Lavalink Version

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
         "version": "13",
         "linkDown": "https://download.java.net/openjdk/jdk13/ri/openjdk-13+33_linux-x64_bin.tar.gz"
     },
-    "lavalink": "https://ci.fredboat.com/repository/download/Lavalink_Build/8841:id/Lavalink.jar?guest=1",
+    "lavalink": "https://ci.fredboat.com/repository/download/Lavalink_Build/8907:id/Lavalink.jar?guest=1",
     
     "fileRunBot": "bot.js",
     "logMODE": false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lavalink-on-javascript",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "main": "index.js",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
The current version of Lavalink 8841 used by Discloud is outdated and does not support Soundcloud, this new version fixes the error "Could not find client ID from application script." from Lavalink.